### PR TITLE
Remove whitespace from XML code snippets

### DIFF
--- a/cache_xml.md
+++ b/cache_xml.md
@@ -18,7 +18,6 @@ The cache.xml file is located in the `app/etc/` directory of your Magento 2 inst
 structure with a root `<config>` element, which contains multiple `<type>` elements representing different cache types.
 
 ```xml
-
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Cache/etc/cache.xsd">
     <type name="cache_type1"/>
@@ -39,7 +38,6 @@ the corresponding `<type>` element. These child elements define various properti
 ### Example: Configuring the `config` Cache Type
 
 ```xml
-
 <type name="config">
     <backend_model>Magento\Framework\Cache\Backend\File</backend_model>
     <backend_model>Magento\Framework\App\Cache\StateInterface</backend_model>

--- a/cron_groups.md
+++ b/cron_groups.md
@@ -20,7 +20,6 @@ The `cron_groups.xml` file follows a specific structure that consists of several
 example of the basic structure:
 
 ```xml
-
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/cron_groups.xsd">
     <group id="default">
@@ -53,7 +52,6 @@ following attribute:
 Example:
 
 ```xml
-
 <group id="default">
     <!-- Group configurations -->
 </group>
@@ -67,7 +65,6 @@ minutes for generating the cron schedule.
 Example:
 
 ```xml
-
 <schedule_generate_every>1</schedule_generate_every>
 ```
 
@@ -79,7 +76,6 @@ is generated. It helps in ensuring that scheduled tasks are executed on time by 
 Example:
 
 ```xml
-
 <schedule_ahead_for>4</schedule_ahead_for>
 ```
 
@@ -91,7 +87,6 @@ this time, the schedule entry for the cron job will be removed from the schedule
 Example:
 
 ```xml
-
 <schedule_lifetime>2</schedule_lifetime>
 ```
 
@@ -103,7 +98,6 @@ minutes for cleaning up the history of executed cron jobs.
 Example:
 
 ```xml
-
 <history_cleanup_every>10</history_cleanup_every>
 ```
 
@@ -115,7 +109,6 @@ removed from the history tables.
 Example:
 
 ```xml
-
 <history_success_lifetime>60</history_success_lifetime>
 ```
 
@@ -127,7 +120,6 @@ from the history tables.
 Example:
 
 ```xml
-
 <history_failure_lifetime>600</history_failure_lifetime>
 ```
 
@@ -139,7 +131,6 @@ separate process. It accepts a boolean value: `0` for false and `1` for true.
 Example:
 
 ```xml
-
 <use_separate_process>0</use_separate_process>
 ```
 

--- a/cron_groups_xml.md
+++ b/cron_groups_xml.md
@@ -22,7 +22,6 @@ The `cron_groups.xml` file follows a specific structure that consists of several
 example of the basic structure:
 
 ```xml
-
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/cron_groups.xsd">
     <group id="default">
@@ -55,7 +54,6 @@ following attribute:
 Example:
 
 ```xml
-
 <group id="default">
     <!-- Group configurations -->
 </group>
@@ -69,7 +67,6 @@ minutes for generating the cron schedule.
 Example:
 
 ```xml
-
 <schedule_generate_every>1</schedule_generate_every>
 ```
 
@@ -81,7 +78,6 @@ is generated. It helps in ensuring that scheduled tasks are executed on time by 
 Example:
 
 ```xml
-
 <schedule_ahead_for>4</schedule_ahead_for>
 ```
 
@@ -93,7 +89,6 @@ this time, the schedule entry for the cron job will be removed from the schedule
 Example:
 
 ```xml
-
 <schedule_lifetime>2</schedule_lifetime>
 ```
 
@@ -105,7 +100,6 @@ minutes for cleaning up the history of executed cron jobs.
 Example:
 
 ```xml
-
 <history_cleanup_every>10</history_cleanup_every>
 ```
 
@@ -117,7 +111,6 @@ removed from the history tables.
 Example:
 
 ```xml
-
 <history_success_lifetime>60</history_success_lifetime>
 ```
 
@@ -129,7 +122,6 @@ from the history tables.
 Example:
 
 ```xml
-
 <history_failure_lifetime>600</history_failure_lifetime>
 ```
 
@@ -141,7 +133,6 @@ separate process. It accepts a boolean value: `0` for false and `1` for true.
 Example:
 
 ```xml
-
 <use_separate_process>0</use_separate_process>
 ```
 

--- a/db_schema.md
+++ b/db_schema.md
@@ -35,7 +35,6 @@ element can have the following attributes:
 Here's an example of defining a table in the `db_schema.xml` file:
 
 ```xml
-
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
     <table name="my_module_table" resource="default" engine="innodb">
@@ -58,7 +57,6 @@ attributes:
 Here's an example of defining columns within a table:
 
 ```xml
-
 <table name="my_module_table" resource="default" engine="innodb">
     <column name="id" dataType="int" nullable="false" comment="ID"/>
     <column name="name" dataType="varchar" length="255" nullable="true"/>
@@ -79,7 +77,6 @@ the following attributes:
 Here's an example of defining an index within a table:
 
 ```xml
-
 <table name="my_module_table" resource="default" engine="innodb">
     <column name="id" dataType="int" nullable="false" comment="ID"/>
     <column name="name" dataType="varchar" length="255" nullable="true"/>
@@ -106,7 +103,6 @@ The `constraint` element can have the following attributes:
 Here's an example of defining a foreign key constraint within a table:
 
 ```xml
-
 <table name="my_module_table" resource="default" engine="innodb">
     <column name="id" dataType="int" nullable="false" comment="ID"/>
     <column name="name" dataType="varchar" length="255" nullable="true"/>

--- a/db_schema_xml.md
+++ b/db_schema_xml.md
@@ -37,7 +37,6 @@ element can have the following attributes:
 Here's an example of defining a table in the `db_schema.xml` file:
 
 ```xml
-
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
     <table name="my_module_table" resource="default" engine="innodb">
@@ -60,7 +59,6 @@ attributes:
 Here's an example of defining columns within a table:
 
 ```xml
-
 <table name="my_module_table" resource="default" engine="innodb">
     <column name="id" dataType="int" nullable="false" comment="ID"/>
     <column name="name" dataType="varchar" length="255" nullable="true"/>
@@ -81,7 +79,6 @@ the following attributes:
 Here's an example of defining an index within a table:
 
 ```xml
-
 <table name="my_module_table" resource="default" engine="innodb">
     <column name="id" dataType="int" nullable="false" comment="ID"/>
     <column name="name" dataType="varchar" length="255" nullable="true"/>
@@ -108,7 +105,6 @@ The `constraint` element can have the following attributes:
 Here's an example of defining a foreign key constraint within a table:
 
 ```xml
-
 <table name="my_module_table" resource="default" engine="innodb">
     <column name="id" dataType="int" nullable="false" comment="ID"/>
     <column name="name" dataType="varchar" length="255" nullable="true"/>

--- a/di.md
+++ b/di.md
@@ -24,7 +24,6 @@ defined. Within a `<type>` element, you can have multiple `<arguments>` and `<pl
 Here's an example of the basic structure of a `di.xml` file:
 
 ```xml
-
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="{Class/Interface}">
@@ -45,7 +44,6 @@ For example, if we want to configure dependencies for the `Magento\Catalog\Api\P
 the `<type>` element would look like this:
 
 ```xml
-
 <type name="Magento\Catalog\Api\ProductRepositoryInterface">
     <!-- Define dependencies here -->
 </type>
@@ -60,7 +58,6 @@ Here's an example of how to define constructor arguments for the `Magento\Catalo
 interface:
 
 ```xml
-
 <type name="Magento\Catalog\Api\ProductRepositoryInterface">
     <arguments>
         <argument xsi:type="object" name="productFactory">Magento\Catalog\Model\ProductFactory</argument>
@@ -84,7 +81,6 @@ implements the plugin), and the name of the method you want to intercept.
 Here's an example of how to define a plugin for the `Magento\Catalog\Api\ProductRepositoryInterface` interface:
 
 ```xml
-
 <type name="Magento\Catalog\Api\ProductRepositoryInterface">
     <plugin name="my_plugin" type="MyVendor\MyModule\Plugin\ProductRepositoryPlugin" sortOrder="10" disabled="false"/>
 </type>

--- a/di_xml.md
+++ b/di_xml.md
@@ -26,7 +26,6 @@ defined. Within a `<type>` element, you can have multiple `<arguments>` and `<pl
 Here's an example of the basic structure of a `di.xml` file:
 
 ```xml
-
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="{Class/Interface}">
@@ -47,7 +46,6 @@ For example, if we want to configure dependencies for the `Magento\Catalog\Api\P
 the `<type>` element would look like this:
 
 ```xml
-
 <type name="Magento\Catalog\Api\ProductRepositoryInterface">
     <!-- Define dependencies here -->
 </type>
@@ -62,7 +60,6 @@ Here's an example of how to define constructor arguments for the `Magento\Catalo
 interface:
 
 ```xml
-
 <type name="Magento\Catalog\Api\ProductRepositoryInterface">
     <arguments>
         <argument xsi:type="object" name="productFactory">Magento\Catalog\Model\ProductFactory</argument>
@@ -86,7 +83,6 @@ implements the plugin), and the name of the method you want to intercept.
 Here's an example of how to define a plugin for the `Magento\Catalog\Api\ProductRepositoryInterface` interface:
 
 ```xml
-
 <type name="Magento\Catalog\Api\ProductRepositoryInterface">
     <plugin name="my_plugin" type="MyVendor\MyModule\Plugin\ProductRepositoryPlugin" sortOrder="10" disabled="false"/>
 </type>

--- a/email_templates_xml.md
+++ b/email_templates_xml.md
@@ -21,7 +21,6 @@ The `email_templates.xml` file follows a specific XML structure that defines the
 configurations. Here is a basic example of the structure:
 
 ```xml
-
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Email:etc/email_templates.xsd">
     <template id="template_id" label="Template Label" file="file_name.html" type="html">
@@ -51,7 +50,6 @@ To create a new email template, you need to add a `<template>` element inside th
 the `email_templates.xml` file. Here's an example:
 
 ```xml
-
 <template id="custom_template" label="Custom Template" file="custom_template.html" type="html">
     <!-- Variable definitions and CSS styles go here -->
 </template>
@@ -69,7 +67,6 @@ To define variables for an email template, you need to add `<variable>` elements
 the `<template>` element. Here's an example:
 
 ```xml
-
 <template id="custom_template" label="Custom Template" file="custom_template.html" type="html">
     <variables>
         <variable name="customer_name" xsi:type="string">John Doe</variable>
@@ -97,7 +94,6 @@ attributes. These attributes allow you to specify the subject, sender, and other
 Here's an example of configuring an email template:
 
 ```xml
-
 <template id="custom_template" label="Custom Template" file="custom_template.html" type="html"
           subject="Custom Template Subject" sender_name="Store Name" sender_email="store@example.com">
     <!-- Variable definitions, CSS styles, and email content go here -->
@@ -118,7 +114,6 @@ You can add custom headers to the email template by using the `<headers>` elemen
 Here's an example:
 
 ```xml
-
 <template id="custom_template" label="Custom Template" file="custom_template.html" type="html" ...>
 <headers>
 <header name="X-Custom-Header">Custom Value</header>
@@ -136,7 +131,6 @@ To include attachments in the email template, you can use the `<attachments>` el
 Here's an example:
 
 ```xml
-
 <template id="custom_template" label="Custom Template" file="custom_template.html" type="html" ...>
 <attachments>
 <attachment type="mimetype" encoding="encoding_type">attachment_content</attachment>

--- a/events.md
+++ b/events.md
@@ -64,7 +64,6 @@ convenient way to define observers using XML configuration. Let's create an obse
 1. Create a new XML file `events.xml` in your module's `etc` directory:
 
 ```xml
-
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
     <event name="customer_register_success">
@@ -109,7 +108,6 @@ needs. To create a custom event, follow these steps:
 1. Create a new XML file `events.xml` in your module's `etc` directory:
 
 ```xml
-
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
     <event name="custom_event">

--- a/events_xml.md
+++ b/events_xml.md
@@ -45,7 +45,6 @@ Defining an event in the `events.xml` file is as simple as adding an `event` tag
 an example:
 
 ```xml
-
 <event name="catalog_product_save_after">
     <observer name="catalog_product_save_after_observer" instance="Vendor\Module\Observer\ProductSaveAfter"
               method="execute"/>
@@ -60,7 +59,6 @@ Defining an observer for the event involves adding an `observer` tag inside the 
 specifies the class that will handle this event, while the `method` attribute defines the method that will be called.
 
 ```xml
-
 <observer name="catalog_product_save_after_observer" instance="Vendor\Module\Observer\ProductSaveAfter"
           method="execute"/>
 ```

--- a/extension_attributes.md
+++ b/extension_attributes.md
@@ -126,7 +126,6 @@ class CustomAttributePlugin
 3. Defining an observer for extension attribute changes:
 
 ```xml
-
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
     <event name="extension_attribute_change_event">

--- a/extension_attributes_xml.md
+++ b/extension_attributes_xml.md
@@ -46,7 +46,6 @@ are defining the attribute. The `code` and `type` define the attribute itself.
 Here is an example of adding a custom attribute to the Product entity:
 
 ```xml
-
 <extension_attributes for="Magento\Catalog\Api\Data\ProductInterface">
     <attribute code="custom_attribute" type="string"/>
 </extension_attributes>

--- a/fieldset.md
+++ b/fieldset.md
@@ -14,7 +14,6 @@ Each `<fieldset>` element can contain one or more `<container>` elements, and ea
 or more `<field>` elements. Here is an example of the basic structure of a `fieldset.xml` file:
 
 ```xml
-
 <fieldset>
     <container name="container_name">
         <field name="field_name" sortOrder="sort_order" component="component_name"/>
@@ -32,7 +31,6 @@ Each `fieldset.xml` file can contain multiple `<fieldset>` elements. Here is an 
 multiple `<fieldset>` elements:
 
 ```xml
-
 <fieldset>
     <!-- First fieldset definition -->
 </fieldset>
@@ -49,7 +47,6 @@ and structure the fields. Each `<container>` element can contain one or more `<f
 a `fieldset.xml` file with a `<container>` element:
 
 ```xml
-
 <fieldset>
     <container name="billing_information">
         <field name="first_name" sortOrder="10" component="Magento_Ui/js/form/element/abstract"/>
@@ -65,7 +62,6 @@ component of the field. The name attribute is mandatory, while the sortOrder and
 is an example of a `fieldset.xml` file with a `<field>` element:
 
 ```xml
-
 <fieldset>
     <container name="billing_information">
         <field name="first_name" sortOrder="10" component="Magento_Ui/js/form/element/abstract"/>
@@ -80,7 +76,6 @@ the container or field within the `fieldset.xml` file. The name should be a stri
 For example, a field with the name "first_name" can be defined as follows:
 
 ```xml
-
 <fieldset>
     <container name="billing_information">
         <field name="first_name" sortOrder="10" component="Magento_Ui/js/form/element/abstract"/>
@@ -96,7 +91,6 @@ optional, and if not specified, fields will be rendered in the order they are de
 is an example of a `fieldset.xml` file with fields sorted using the `sortOrder` attribute:
 
 ```xml
-
 <fieldset>
     <container name="billing_information">
         <field name="first_name" sortOrder="10" component="Magento_Ui/js/form/element/abstract"/>
@@ -112,7 +106,6 @@ The component determines the behavior and appearance of the field. The value of 
 valid JavaScript component path. Here is an example of a `fieldset.xml` file with a field component specified:
 
 ```xml
-
 <fieldset>
     <container name="billing_information">
         <field name="first_name" sortOrder="10" component="Magento_Ui/js/form/element/abstract"/>
@@ -127,7 +120,6 @@ the "customer_account_edit" form. We can achieve this by creating a `fieldset.xm
 following content:
 
 ```xml
-
 <fieldset>
     <container name="customer">
         <field name="age" sortOrder="70" component="Magento_Ui/js/form/element/input"/>
@@ -138,7 +130,6 @@ following content:
 After creating the `fieldset.xml` file, we need to declare it in the module's `di.xml` file as follows:
 
 ```xml
-
 <type name="Magento\Customer\Block\Form\Edit">
     <arguments>
         <argument name="formCode" xsi:type="const">\Magento\Customer\Block\Form::FORM_CODE_EDIT</argument>

--- a/fieldset_xml.md
+++ b/fieldset_xml.md
@@ -16,7 +16,6 @@ Each `<fieldset>` element can contain one or more `<container>` elements, and ea
 or more `<field>` elements. Here is an example of the basic structure of a `fieldset.xml` file:
 
 ```xml
-
 <fieldset>
     <container name="container_name">
         <field name="field_name" sortOrder="sort_order" component="component_name"/>
@@ -34,7 +33,6 @@ Each `fieldset.xml` file can contain multiple `<fieldset>` elements. Here is an 
 multiple `<fieldset>` elements:
 
 ```xml
-
 <fieldset>
     <!-- First fieldset definition -->
 </fieldset>
@@ -51,7 +49,6 @@ and structure the fields. Each `<container>` element can contain one or more `<f
 a `fieldset.xml` file with a `<container>` element:
 
 ```xml
-
 <fieldset>
     <container name="billing_information">
         <field name="first_name" sortOrder="10" component="Magento_Ui/js/form/element/abstract"/>
@@ -67,7 +64,6 @@ component of the field. The name attribute is mandatory, while the sortOrder and
 is an example of a `fieldset.xml` file with a `<field>` element:
 
 ```xml
-
 <fieldset>
     <container name="billing_information">
         <field name="first_name" sortOrder="10" component="Magento_Ui/js/form/element/abstract"/>
@@ -82,7 +78,6 @@ the container or field within the `fieldset.xml` file. The name should be a stri
 For example, a field with the name "first_name" can be defined as follows:
 
 ```xml
-
 <fieldset>
     <container name="billing_information">
         <field name="first_name" sortOrder="10" component="Magento_Ui/js/form/element/abstract"/>
@@ -98,7 +93,6 @@ optional, and if not specified, fields will be rendered in the order they are de
 is an example of a `fieldset.xml` file with fields sorted using the `sortOrder` attribute:
 
 ```xml
-
 <fieldset>
     <container name="billing_information">
         <field name="first_name" sortOrder="10" component="Magento_Ui/js/form/element/abstract"/>
@@ -114,7 +108,6 @@ The component determines the behavior and appearance of the field. The value of 
 valid JavaScript component path. Here is an example of a `fieldset.xml` file with a field component specified:
 
 ```xml
-
 <fieldset>
     <container name="billing_information">
         <field name="first_name" sortOrder="10" component="Magento_Ui/js/form/element/abstract"/>
@@ -129,7 +122,6 @@ the "customer_account_edit" form. We can achieve this by creating a `fieldset.xm
 following content:
 
 ```xml
-
 <fieldset>
     <container name="customer">
         <field name="age" sortOrder="70" component="Magento_Ui/js/form/element/input"/>
@@ -140,7 +132,6 @@ following content:
 After creating the `fieldset.xml` file, we need to declare it in the module's `di.xml` file as follows:
 
 ```xml
-
 <type name="Magento\Customer\Block\Form\Edit">
     <arguments>
         <argument name="formCode" xsi:type="const">\Magento\Customer\Block\Form::FORM_CODE_EDIT</argument>

--- a/glossary-of-terms.md
+++ b/glossary-of-terms.md
@@ -106,7 +106,6 @@ and determine which blocks to display on different pages.
 Example:
 
 ```xml
-
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>

--- a/how-to-use-and-extend-apis.md
+++ b/how-to-use-and-extend-apis.md
@@ -102,7 +102,6 @@ Here's an example of how to create a custom API endpoint for retrieving a list o
 2. Define a new route in `etc/webapi.xml`:
 
 ```xml
-
 <routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
     <route url="/V1/custom-products" method="GET" identity="Vendor_CustomApi::customProducts"/>
@@ -211,7 +210,6 @@ class ProductRepository implements ProductRepositoryInterface
 4. Register your custom implementation in `di.xml`:
 
 ```xml
-
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <preference for="Vendor\CustomApi\Api\ProductRepositoryInterface" type="Vendor\CustomApi\Model\ProductRepository"/>
@@ -271,7 +269,6 @@ class ProductRepositoryPlugin
 3. Register your plugin in `di.xml`:
 
 ```xml
-
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="Magento\Catalog\Api\ProductRepositoryInterface">

--- a/indexer.md
+++ b/indexer.md
@@ -51,7 +51,6 @@ view.
 Here is an example of a custom indexer definition:
 
 ```xml
-
 <indexer id="my_custom_indexer" view_id="my_custom_indexer">
     <!-- Indexer configuration goes here -->
 </indexer>
@@ -72,7 +71,6 @@ options include:
 Here is an example of a custom indexer configuration:
 
 ```xml
-
 <indexer id="my_custom_indexer" view_id="my_custom_indexer">
     <title>My Custom Indexer</title>
     <description>This indexer updates the custom data in the database.</description>
@@ -93,7 +91,6 @@ more `<data_source>` sections to specify the sources of data.
 Here is an example of a data source configuration:
 
 ```xml
-
 <data_source name="[Data_Source_Name]">
     <!-- Data source configuration goes here -->
 </data_source>

--- a/indexers.md
+++ b/indexers.md
@@ -43,7 +43,6 @@ To configure an indexer, you define it in the `indexer.xml` file with its associ
 an example of configuring a custom indexer:
 
 ```xml
-
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Indexer/etc/indexer.xsd">
     <indexer id="custom_indexer" view_id="custom_indexer" class="[Vendor]\[Module]\Indexer\CustomIndexer">

--- a/layout_xml.md
+++ b/layout_xml.md
@@ -25,7 +25,6 @@ optional attributes like `class`, `template`, and `cacheable`.
 Example:
 
 ```xml
-
 <block name="custom.block" class="Vendor\Namespace\Block\CustomBlock" template="Vendor_Namespace::custom_block.phtml"/>
 ```
 
@@ -44,7 +43,6 @@ attributes like `htmlTag`, `before`, `after`, and `label`.
 Example:
 
 ```xml
-
 <container name="custom.container" htmlTag="div" label="Custom Container">
     <block name="custom.block" class="Vendor\Namespace\Block\CustomBlock"
            template="Vendor_Namespace::custom_block.phtml"/>
@@ -64,7 +62,6 @@ modify blocks or containers defined by other modules.
 Example:
 
 ```xml
-
 <referenceContainer name="header.container">
     <container name="custom.container" htmlTag="div" label="Custom Container" after="logo"/>
 </referenceContainer>
@@ -82,7 +79,6 @@ include `htmlTag`, `before`, `after`, `label`, `as`, `output`, and `cacheable`.
 Example:
 
 ```xml
-
 <block name="custom.block" class="Vendor\Namespace\Block\CustomBlock" template="Vendor_Namespace::custom_block.phtml"
        htmlTag="div" before="-" after="footer.container" label="Custom Block" as="custom.block.alias" output="toHtml"
        cacheable="true"/>

--- a/layouts-blocks-and-templates.md
+++ b/layouts-blocks-and-templates.md
@@ -97,7 +97,6 @@ class RecentProducts extends Template
 Now, in your layout file, you can add the `RecentProducts` block to the desired container.
 
 ```xml
-
 <block class="Vendor\Module\Block\RecentProducts" name="recent_products"
        template="Vendor_Module::recent_products.phtml"/>
 ```

--- a/menu.md
+++ b/menu.md
@@ -12,7 +12,6 @@ The `menu.xml` file uses XML tags to define the structure of the menu. Each menu
 the `<menu>` tag. Here is an example of a simple menu structure:
 
 ```xml
-
 <config>
     <menu>
         <add id="Vendor_Module::menu_item1"
@@ -54,7 +53,6 @@ The `<resource>` tag is used to specify the ACL resource that controls access to
 define a unique ACL resource for each menu item to manage user permissions effectively. For example:
 
 ```xml
-
 <add id="Vendor_Module::menu_item3"
      title="Menu Item 3"
      module="Vendor_Module"
@@ -70,7 +68,6 @@ You can add icons to your menu items using the `<add>` tag's `resource` attribut
 icons provided by the Font Awesome library. For example:
 
 ```xml
-
 <add id="Vendor_Module::menu_item4"
      title="Menu Item 4"
      module="Vendor_Module"
@@ -92,7 +89,6 @@ You can create submenus by adding multiple levels of menu items. Each submenu is
 within the parent menu item's `<add>` tag. For example:
 
 ```xml
-
 <add id="Vendor_Module::menu_item5"
      title="Menu Item 5"
      module="Vendor_Module"

--- a/menu_xml.md
+++ b/menu_xml.md
@@ -14,7 +14,6 @@ The `menu.xml` file uses XML tags to define the structure of the menu. Each menu
 the `<menu>` tag. Here is an example of a simple menu structure:
 
 ```xml
-
 <config>
     <menu>
         <add id="Vendor_Module::menu_item1"
@@ -56,7 +55,6 @@ The `<resource>` tag is used to specify the ACL resource that controls access to
 define a unique ACL resource for each menu item to manage user permissions effectively. For example:
 
 ```xml
-
 <add id="Vendor_Module::menu_item3"
      title="Menu Item 3"
      module="Vendor_Module"
@@ -72,7 +70,6 @@ You can add icons to your menu items using the `<add>` tag's `resource` attribut
 icons provided by the Font Awesome library. For example:
 
 ```xml
-
 <add id="Vendor_Module::menu_item4"
      title="Menu Item 4"
      module="Vendor_Module"
@@ -94,7 +91,6 @@ You can create submenus by adding multiple levels of menu items. Each submenu is
 within the parent menu item's `<add>` tag. For example:
 
 ```xml
-
 <add id="Vendor_Module::menu_item5"
      title="Menu Item 5"
      module="Vendor_Module"

--- a/module-development.md
+++ b/module-development.md
@@ -225,7 +225,6 @@ In this example, `$block` refers to an instance of `CustomBlock`.
 4. Use your block and template in a layout XML file. Here's an example:
 
 ```xml
-
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>

--- a/observers.md
+++ b/observers.md
@@ -96,7 +96,6 @@ If you have multiple observers for the same event, you can define the execution 
 attribute in the observer registration. Observers with lower sequence values will execute first.
 
 ```xml
-
 <observer name="first_observer" instance="Vendor\Module\Observer\FirstObserver" sequence="10"/>
 <observer name="second_observer" instance="Vendor\Module\Observer\SecondObserver" sequence="20"/>
 ```

--- a/overview-of-the-architectural-components.md
+++ b/overview-of-the-architectural-components.md
@@ -43,7 +43,6 @@ In Magento 2, Views are implemented using XML and PHTML templates.
 Example (XML layout file):
 
 ```xml
-
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
@@ -127,7 +126,6 @@ dependencies from a centralized container, reducing coupling and enabling module
 Example (DI configuration file):
 
 ```xml
-
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <preference for="Vendor\Module\Api\ProductServiceInterface" type="Vendor\Module\Model\ProductService"/>

--- a/plugins.md
+++ b/plugins.md
@@ -100,7 +100,6 @@ To use a plugin in Magento 2, you need to define its configuration in your modul
 how to configure a plugin for a class `TargetClass`:
 
 ```xml
-
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="TargetClass">

--- a/rest-apis-soap-apis.md
+++ b/rest-apis-soap-apis.md
@@ -107,7 +107,6 @@ Let's consider an example SOAP API method that retrieves user information.
 **Response:**
 
 ```xml
-
 <getUserInfoResponse>
     <getUserInfoResult>
         <id>123</id>

--- a/routes.md
+++ b/routes.md
@@ -16,7 +16,6 @@ and consists of multiple elements that define the routes and their associated co
 Here is an example of the basic structure of a `routes.xml` file:
 
 ```xml
-
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
     <router id="[ROUTER_ID]">
@@ -100,7 +99,6 @@ named `Acme_CustomModule` that needs to define a custom route for frontend pages
 Here is the `routes.xml` file for this module:
 
 ```xml
-
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
     <router id="standard">

--- a/routes_xml.md
+++ b/routes_xml.md
@@ -18,7 +18,6 @@ and consists of multiple elements that define the routes and their associated co
 Here is an example of the basic structure of a `routes.xml` file:
 
 ```xml
-
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
     <router id="[ROUTER_ID]">
@@ -70,7 +69,6 @@ named `Acme_CustomModule` that needs to define a custom route for frontend pages
 Here is the `routes.xml` file for this module:
 
 ```xml
-
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
     <router id="standard">

--- a/search.md
+++ b/search.md
@@ -68,7 +68,6 @@ To customize the search index in Magento 2, you can create a custom module and d
 file specifies the attributes to be included in the search index. Here's an example `search_request.xml` file:
 
 ```xml
-
 <requests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:noNamespaceSchemaLocation="urn:magento:framework:Search/etc/search_request.xsd">
     <request query="quick_search_container">

--- a/system_xml.md
+++ b/system_xml.md
@@ -27,7 +27,6 @@ section.
 Here is an example of a basic system.xml file structure:
 
 ```xml
-
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
@@ -50,7 +49,6 @@ Each `<section>` element must contain a unique `id` attribute to identify the se
 Here is an example of defining a configuration section named "General" with an associated group:
 
 ```xml
-
 <section id="general" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
     <label>General Settings</label>
     <tab>my_custom_tab</tab>
@@ -81,7 +79,6 @@ Each `<field>` element must have a unique `id` attribute to identify the field.
 Here is an example of defining a text field within a group:
 
 ```xml
-
 <field id="my_text_field" translate="label" type="text" sort_order="10" show_in_default="1" show_in_website="1"
        show_in_store="1">
     <label>My Text Field</label>
@@ -113,7 +110,6 @@ that can be set.
 Here is an example of defining a select field:
 
 ```xml
-
 <field id="my_select_field" translate="label" type="select" sort_order="20" show_in_default="1" show_in_website="1"
        show_in_store="1">
     <label>My Select Field</label>
@@ -132,7 +128,6 @@ These rules are specified using the `<validate>` element within the `<field>` de
 Here is an example of defining validation rules for a text field:
 
 ```xml
-
 <field id="my_text_field" translate="label" type="text" sort_order="10" show_in_default="1" show_in_website="1"
        show_in_store="1">
     <label>My Text Field</label>

--- a/the-magento-application.md
+++ b/the-magento-application.md
@@ -51,7 +51,6 @@ For example, to add a new block to the homepage, create a layout file named `cms
 directory. Inside the file, define the block using XML tags:
 
 ```xml
-
 <referenceContainer name="content">
     <block class="Magento\Framework\View\Element\Template" name="custom.block" template="custom_block.phtml"/>
 </referenceContainer>

--- a/theme-development.md
+++ b/theme-development.md
@@ -37,7 +37,6 @@ To create a custom theme in Magento 2, follow these steps:
    configuration options. Here's an example:
 
 ```xml
-
 <theme xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="urn:magento:framework:Config/etc/theme.xsd">
     <title>MyTheme</title>
@@ -74,7 +73,6 @@ makes it easier to maintain themes. To inherit from a parent theme, specify it i
 theme using the `<parent>` tag. Here's an example:
 
 ```xml
-
 <parent>Magento/luma</parent>
 ```
 
@@ -95,7 +93,6 @@ are used to specify the location of blocks within containers.
 Here's an example of a simple layout XML file that adds a block to the homepage:
 
 ```xml
-
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column"
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
@@ -160,7 +157,6 @@ To configure your theme, create a file called `view.xml` within your theme's `et
 settings, such as image sizes, color swatches, and other visual aspects of your theme. Here's an example:
 
 ```xml
-
 <view xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="urn:magento:framework:Config/etc/view.xsd">
     <media>

--- a/unit-testing.md
+++ b/unit-testing.md
@@ -121,7 +121,6 @@ Magento 2 allows the creation of data fixtures to provide consistent test data f
 in XML files and can be used to set up test scenarios.
 
 ```xml
-
 <testData>
     <fixture>
         <name>my_module_data</name>

--- a/view_xml.md
+++ b/view_xml.md
@@ -23,7 +23,6 @@ The `<vars>` section allows you to define and override CSS variables. These vari
 to control various CSS properties. Here's an example of how to define a variable:
 
 ```xml
-
 <vars module="Magento_Theme">
     <var name="customVariable">red</var>
 </vars>
@@ -44,7 +43,6 @@ The `<colors>` section allows you to define and override color values used in yo
 various elements such as text, buttons, links, and more. Here's an example:
 
 ```xml
-
 <colors>
     <color name="text.base">black</color>
     <color name="button.primary">blue</color>
@@ -66,7 +64,6 @@ The `<images>` section is used to define image-related configuration. You can sp
 other properties. Here's an example:
 
 ```xml
-
 <images module="Magento_Theme">
     <image id="product_page_main_image" type="image">
         <width>1000</width>
@@ -84,7 +81,6 @@ The `<templates>` section allows you to define and override template files used 
 template files to use for different elements of the frontend. Here's an example:
 
 ```xml
-
 <templates>
     <template id="Magento_Catalog::product/list.phtml">
         <overwrite>true</overwrite>
@@ -102,7 +98,6 @@ The `<layout>` section defines the layout configuration for your theme. You can 
 different pages and blocks. Here's an example:
 
 ```xml
-
 <layout>
     <updates>
         <update id="my_custom_layout"/>
@@ -120,7 +115,6 @@ appearance of the product image on the product detail page. You can achieve this
 your `view.xml` file:
 
 ```xml
-
 <images module="Magento_Catalog">
     <image id="product_page_main_image" type="image">
         <width>800</width>

--- a/webapi.md
+++ b/webapi.md
@@ -27,7 +27,6 @@ element, you define different routes that correspond to different parts of your 
 Example:
 
 ```xml
-
 <routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
     <!-- Route definitions go here -->
@@ -42,7 +41,6 @@ endpoint for accessing the web API. Within the `route` element, you define the s
 Example:
 
 ```xml
-
 <route url="/V1" method="GET">
     <!-- Service definitions go here -->
 </route>
@@ -59,7 +57,6 @@ accessing that service and also contains the methods associated with that servic
 Example:
 
 ```xml
-
 <service class="Magento\Catalog\Api\ProductRepositoryInterface" method="get">
     <!-- Method definitions go here -->
 </service>
@@ -78,7 +75,6 @@ further configure the behavior of the method.
 Example:
 
 ```xml
-
 <method name="get" entity_type="Magento\Catalog\Api\Data\ProductInterface">
     <!-- Method configuration goes here -->
 </method>

--- a/webapi_xml.md
+++ b/webapi_xml.md
@@ -29,7 +29,6 @@ element, you define different routes that correspond to different parts of your 
 Example:
 
 ```xml
-
 <routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
     <!-- Route definitions go here -->
@@ -44,7 +43,6 @@ endpoint for accessing the web API. Within the `route` element, you define the s
 Example:
 
 ```xml
-
 <route url="/V1" method="GET">
     <!-- Service definitions go here -->
 </route>
@@ -61,7 +59,6 @@ accessing that service and also contains the methods associated with that servic
 Example:
 
 ```xml
-
 <service class="Magento\Catalog\Api\ProductRepositoryInterface" method="get">
     <!-- Method definitions go here -->
 </service>
@@ -80,7 +77,6 @@ further configure the behavior of the method.
 Example:
 
 ```xml
-
 <method name="get" entity_type="Magento\Catalog\Api\Data\ProductInterface">
     <!-- Method configuration goes here -->
 </method>

--- a/widget.md
+++ b/widget.md
@@ -19,7 +19,6 @@ The `<widget>` element is the main building block of the `widget.xml` file. It d
 is an example:
 
 ```xml
-
 <widget id="example_widget" class="Vendor\ExampleWidget\Block\Widget\Example">
     <label translate="true">Example Widget</label>
     <description translate="true">This is an example widget.</description>
@@ -59,7 +58,6 @@ The `<parameter>` element defines a configuration option for the widget. It can 
 select, boolean, etc. Here is an example:
 
 ```xml
-
 <parameters>
     <parameter name="title" xsi:type="text" required="true">
         <label translate="true">Title</label>
@@ -88,7 +86,6 @@ The `<container>` element defines a layout container where the widget can be pla
 template file for rendering the widget. Here is an example:
 
 ```xml
-
 <containers>
     <container name="content.top">
         <template name="widget/example.phtml">
@@ -109,7 +106,6 @@ The `<block>` element specifies the block types supported by the widget. The sup
 blocks within the widget. Here is an example:
 
 ```xml
-
 <supportedBlocks>
     <block name="catalog/product_list"/>
     <block name="cms/block"/>

--- a/widget_xml.md
+++ b/widget_xml.md
@@ -21,7 +21,6 @@ The `<widget>` element is the main building block of the `widget.xml` file. It d
 is an example:
 
 ```xml
-
 <widget id="example_widget" class="Vendor\ExampleWidget\Block\Widget\Example">
     <label translate="true">Example Widget</label>
     <description translate="true">This is an example widget.</description>
@@ -61,7 +60,6 @@ The `<parameter>` element defines a configuration option for the widget. It can 
 select, boolean, etc. Here is an example:
 
 ```xml
-
 <parameters>
     <parameter name="title" xsi:type="text" required="true">
         <label translate="true">Title</label>
@@ -90,7 +88,6 @@ The `<container>` element defines a layout container where the widget can be pla
 template file for rendering the widget. Here is an example:
 
 ```xml
-
 <containers>
     <container name="content.top">
         <template name="widget/example.phtml">
@@ -111,7 +108,6 @@ The `<block>` element specifies the block types supported by the widget. The sup
 blocks within the widget. Here is an example:
 
 ```xml
-
 <supportedBlocks>
     <block name="catalog/product_list"/>
     <block name="cms/block"/>

--- a/widgets.md
+++ b/widgets.md
@@ -95,7 +95,6 @@ For example, to include a **Catalog Products List** widget in the homepage, add 
 theme's `cms_index_index.xml` layout file:
 
 ```xml
-
 <container name="content.top">
     <referenceContainer name="content">
         <container name="widget.container" htmlTag="div" htmlClass="widget-container">

--- a/working-with-adminhtml.md
+++ b/working-with-adminhtml.md
@@ -29,7 +29,6 @@ corresponding controller action.
 To create an admin route, define the route in `adminhtml/routes.xml` in your custom module:
 
 ```xml
-
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
     <router id="admin">
@@ -72,7 +71,6 @@ appearance of the page.
 To create a layout file, create `your_module_controller_action.xml` in `Your/Module/view/adminhtml/layout/`:
 
 ```xml
-
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
@@ -146,7 +144,6 @@ access different functionalities easily.
 To add a custom menu item, create `menu.xml` in `Your/Module/etc/adminhtml/`:
 
 ```xml
-
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Backend:etc/menu.xsd">
     <menu>
@@ -167,7 +164,6 @@ specific actions or access certain pages.
 To define an ACL, create `acl.xml` in `Your/Module/etc/adminhtml/`:
 
 ```xml
-
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
     <acl>


### PR DESCRIPTION
Removes whitespaces from the beginning of code blocks for XML snippets

![Screenshot 2023-08-22 at 10 15 45](https://github.com/mage-os/devdocs/assets/8039493/35cb9778-fe2e-4c99-97f0-fb6c8ccd6b47)
