### PR TITLE
[#72] add markdownlint-cli2-action

### DIFF
--- a/.github/workflows/changed.yml
+++ b/.github/workflows/changed.yml
@@ -1,0 +1,19 @@
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - uses: tj-actions/changed-files@v39
+      id: changed-files
+      with:
+        files: '**/*.md'
+        separator: ","
+    - uses: DavidAnson/markdownlint-cli2-action@v13
+      if: steps.changed-files.outputs.any_changed == 'true'
+      with:
+        globs: ${{ steps.changed-files.outputs.all_changed_files }}
+        separator: ","


### PR DESCRIPTION
It adds https://github.com/marketplace/actions/markdownlint-cli2-action
from https://github.com/DavidAnson/markdownlint-cli2-action/blob/main/.github/workflows/changed.yml

Example:

<img width="1178" alt="image" src="https://github.com/mage-os/devdocs/assets/7961978/a316a2aa-b1c4-4eab-a38f-c50579d6ebc4">
